### PR TITLE
Fix for descripto.value as an AsyncFunction

### DIFF
--- a/src/lib/decorators/MessageGuard.ts
+++ b/src/lib/decorators/MessageGuard.ts
@@ -1,6 +1,7 @@
 export const MessageGuard = (messageType = '') => {
-  return (target: any, propertyKey: string, descriptor: PropertyDescriptor) => {
-    const originalMethod = descriptor.value;
+  return async (target: any, propertyKey: string, descriptor: PropertyDescriptor) => {
+    // console.log(descriptor);
+    const originalMethod = await descriptor.value;
 
     descriptor.value = async function (...arguments_: any) {
       if (!this.value.authenticated) {


### PR DESCRIPTION
In `MessageGuard.ts`, I noticed that `descriptor.value` is an `AsyncFunction` that was not being treated as such.